### PR TITLE
Add direct call function in SwapQuoter

### DIFF
--- a/src/quoter.ts
+++ b/src/quoter.ts
@@ -1,5 +1,6 @@
-import { Interface } from '@ethersproject/abi'
-import { BigintIsh, Currency, CurrencyAmount, TradeType } from '@uniswap/sdk-core'
+import { Interface, defaultAbiCoder, BigNumber } from '@ethersproject/abi'
+import { Provider } from '@ethersproject/abstract-provider';
+import { BigintIsh, Currency, CurrencyAmount, TradeType, CHAIN_TO_ADDRESSES_MAP, SUPPORTED_CHAINS } from '@uniswap/sdk-core'
 import { encodeRouteToPath, MethodParameters, toHex } from './utils'
 import IQuoter from '@uniswap/v3-periphery/artifacts/contracts/lens/Quoter.sol/Quoter.json'
 import IQuoterV2 from '@uniswap/swap-router-contracts/artifacts/contracts/lens/QuoterV2.sol/QuoterV2.json'
@@ -30,8 +31,7 @@ interface BaseQuoteParams {
 }
 
 /**
- * Represents the Uniswap V3 QuoterV1 contract with a method for returning the formatted
- * calldata needed to call the quoter contract.
+ * Represents the Uniswap V3 QuoterV1 and QuoterV2 contract.
  */
 export abstract class SwapQuoter {
   public static V1INTERFACE: Interface = new Interface(IQuoter.abi)
@@ -96,5 +96,53 @@ export abstract class SwapQuoter {
       calldata,
       value: toHex(0),
     }
+  }
+
+  /**
+   * Utility function to directly return a quote without the need to handle calldata from the user.
+   * Uses quoteCallParameters internally. Always uses QuoterV2.
+   * @template TInput The input token, either Ether or an ERC-20
+   * @template TOutput The output token, either Ether or an ERC-20
+   * @param route The swap route, a list of pools through which a swap can occur
+   * @param amount The amount of the quote, either an amount in, or an amount out
+   * @param tradeType The trade type, either exact input or exact output
+   * @returns The decoded result of the Quoter call
+   */
+  public static async callQuoter<TInput extends Currency, TOutput extends Currency>(
+    route: Route<TInput, TOutput>,
+    amount: CurrencyAmount<TInput | TOutput>,
+    tradeType: TradeType,
+    provider: Provider
+  ): Promise<BigInt> {
+    const chainId = amount.currency.chainId
+    const chain = SUPPORTED_CHAINS[chainId]
+
+    invariant(chain !== undefined, 'Unsupported Chain')
+
+    const contractAddresses = CHAIN_TO_ADDRESSES_MAP[chain]
+    // TODO: Add QuoterV2 here when the issue in the sdk-core is resolved.
+    const quoterV2Address = contractAddresses.quoterAddress
+
+    invariant(contractAddresses)
+
+    const methodParameters = this.quoteCallParameters(
+      route, 
+      amount, 
+      tradeType,
+      {
+        useQuoterV2: true
+      }
+    )
+    const quoteCallReturnValue = await provider.call({
+      to: quoterV2Address,
+      data: methodParameters.calldata
+    })
+
+    const decodedEthersValue: BigNumber = defaultAbiCoder.decode(['uint256'], quoteCallReturnValue)
+    const bigintQuoterValue = decodedEthersValue.toBigInt()
+
+    invariant(typeof bigintQuoterValue === "bigint" , 'Could not decode quoter response')
+
+    return bigintQuoterValue
   }
 }


### PR DESCRIPTION
Add a function to the SwapQuoter that directly fetches the address of the contract on the given network, calls the quoter using the quoteCallParamters function and returns the quoted output amount as a decoded bigint value.