### PR TITLE
Add simple single hop quoting functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "⚒️ An SDK for building applications on top of Uniswap V3",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
Previously there was no function to get a quote on a pool without fetching metadata of the pool. Added a function to call quoteExactInputSingle and quoteExactOutputSingle on the quoter class. Always uses QuoterV2.